### PR TITLE
Handlers

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -238,6 +238,8 @@ func PurlShowFile(w http.ResponseWriter, r *http.Request) {
 
 	datasource.LogRecordAccess(r, repo.Id, purl.Id)
 
+	// this uses the filename that the client passed us...should we use
+	// the filename stored in the purl record instead?
 	setResponseContent(w, resp, vars["filename"])
 
 	if r.ContentLength > 0 {

--- a/router_test.go
+++ b/router_test.go
@@ -25,11 +25,11 @@ func TestShowFile(t *testing.T) {
 		{path: "/view/504/any.pdf", status: 200, body: "hello world",
 			headers: map[string]string{
 				"Content-Type":        "application/qqq",
-				"Content-Disposition": "inline; filename=$any.pdf"}},
+				"Content-Disposition": "inline; filename=any.pdf"}},
 		{path: "/view/505/any.pdf", status: 200, body: "a very",
 			headers: map[string]string{
 				"Content-Length":      "6",
-				"Content-Disposition": "inline; filename=$any.pdf"}},
+				"Content-Disposition": "inline; filename=any.pdf"}},
 	}
 
 	for _, test := range table {

--- a/router_test.go
+++ b/router_test.go
@@ -19,17 +19,34 @@ func TestShowFile(t *testing.T) {
 		{path: "/view/123456789/any.pdf", status: 404, body: `{"code":404,"text":"Not Found"}` + "\n",
 			headers: map[string]string{"Content-Type": "application/json; charset=UTF-8"}},
 		{path: "/view/500/any.pdf", status: 200, body: "a very good file"},
+		// upstream is 404
 		{path: "/view/501/any.pdf", status: 500, body: "Content Unavailable\n"},
+		// redirects? (vs proxy)
 		{path: "/view/502/any.pdf", status: 500, body: "hello world"},
 		{path: "/view/503/any.pdf", status: 200, body: "hello world"},
+		// propagate content type from upstream?
 		{path: "/view/504/any.pdf", status: 200, body: "hello world",
 			headers: map[string]string{
 				"Content-Type":        "application/qqq",
 				"Content-Disposition": "inline; filename=any.pdf"}},
+		// propagage content length from upstream?
 		{path: "/view/505/any.pdf", status: 200, body: "a very",
 			headers: map[string]string{
 				"Content-Length":      "6",
 				"Content-Disposition": "inline; filename=any.pdf"}},
+		// test the inline/attachment switch (.zip, .ovf, .vmdk extensions)
+		{path: "/view/505/any.zip", status: 200, body: "a very",
+			headers: map[string]string{
+				"Content-Length":      "6",
+				"Content-Disposition": "attachment; filename=any.zip"}},
+		{path: "/view/505/any.ovf", status: 200, body: "a very",
+			headers: map[string]string{
+				"Content-Length":      "6",
+				"Content-Disposition": "attachment; filename=any.ovf"}},
+		{path: "/view/505/any.vmdk", status: 200, body: "a very",
+			headers: map[string]string{
+				"Content-Length":      "6",
+				"Content-Disposition": "attachment; filename=any.vmdk"}},
 	}
 
 	for _, test := range table {


### PR DESCRIPTION
* Consolidate common tasks into subroutines.
* Add more functional tests for the http handlers
* Remove the negative content length testing since 1) the go stdlib never returns a negative
content length--it just complains about them, and 2) the negative length was only returned on
HEAD requests, which this code does not do. So there is no need to do it.
* When proxying content, make sure we honor the upstream content-length header. This is only
a problem if upstream returns more data than it said it would.
* Add the fedora username and password directly to the http request rather than doing a string substitution into the URL.
* Do not prefix attachment filenames with a dollar sign.