### PR TITLE
Add record suppression marker

### DIFF
--- a/router_test.go
+++ b/router_test.go
@@ -52,6 +52,8 @@ func TestShowFile(t *testing.T) {
 			headers: map[string]string{
 				"Content-Length":      "6",
 				"Content-Disposition": "attachment; filename=longfilename.zip"}},
+		// suppressed record
+		{path: "/view/508/download", status: 404},
 	}
 
 	for _, test := range table {
@@ -82,7 +84,7 @@ func checkSimpleGetRequest(t *testing.T, server *httptest.Server, test URLTest) 
 	if test.body != "" && string(b) != test.body {
 		t.Errorf("On %s received body: %s\n    expected: %s", test.path, b, test.body)
 	}
-	t.Log(resp)
+	//t.Log(resp)
 	for header, expected := range test.headers {
 		received := resp.Header.Get(header)
 		if received != expected {
@@ -187,6 +189,12 @@ func init() {
 			URL:         dummyServer.URL + "/200?data=a+very+long+text&size=6",
 			Information: "",
 		},
+		{
+			ID:          508,
+			Filename:    "suppressed",
+			URL:         dummyServer.URL + "/200-",
+			Information: "",
+		},
 	}
 	for _, seed := range seedItems {
 		seed.RepoID = seed.ID
@@ -210,7 +218,7 @@ func dummyHandler(w http.ResponseWriter, r *http.Request) {
 	data := r.FormValue("data")
 	typ := r.FormValue("type")
 	size := r.FormValue("size")
-	if status < 0 || status >= 1000 {
+	if status <= 0 || status >= 1000 {
 		// REALLY bad status. normalize it
 		status = 400
 	}

--- a/templates/admin-search
+++ b/templates/admin-search
@@ -14,7 +14,7 @@
         <tr>
             <td><a href="/view/{{.ID}}">{{.ID}}</a></td>
             <td>{{.Filename}}</td>
-            <td><a href="{{.URL}}">{{.Filename}} Repo Link</a></td>
+            <td>{{if isSuppressed .}}Suppressed{{else}}<a href="{{.URL}}">{{.Filename}} Repo Link</a>{{end}}</td>
             <td><a href="/view/{{.ID}}/{{.Filename}}">{{.Filename}} PURL</a></td>
             <td>{{.AccessCount}}</td>
             <td>{{.LastAccessed.Format "2006-01-02"}}</td>

--- a/templates/view
+++ b/templates/view
@@ -20,7 +20,7 @@
         </tr>
         <tr>
             <td>Repository URL</td>
-            <td><a href="{{.URL}}">{{.URL}} </a></td>
+            <td>{{if isSuppressed .}}Suppressed{{else}}<a href="{{.URL}}">{{.URL}}</a>{{end}}</td>
         </tr>
         <tr>
             <td>PURL</td>


### PR DESCRIPTION
The marker is appending a hyphen to the URL. It is not the best marker, since hyphens are legal in URLs. Also it is textual, so if a URL has parameters, the hyphen goes at the end of a parameter. But I think it is good enough for now. (Open to alternative suggestions)